### PR TITLE
remove reserve capacity

### DIFF
--- a/Sources/Async/Futures/Future.swift
+++ b/Sources/Async/Futures/Future.swift
@@ -29,7 +29,6 @@ public final class Future<T>: FutureType {
     /// Can only be created by a Promise, so this is hidden
     internal init() {
         awaiters = []
-        awaiters.reserveCapacity(5)
         result = nil
     }
 


### PR DESCRIPTION
This ended up costing much more performance than it gained because already completed promises their futures had an extra overhead