### PR TITLE
Add a pending timer to DispatchEventLoop

### DIFF
--- a/Sources/Async/EventLoop/Dispatch/DispatchEventLoop.swift
+++ b/Sources/Async/EventLoop/Dispatch/DispatchEventLoop.swift
@@ -42,8 +42,30 @@ public final class DispatchEventLoop: EventLoop {
 
     /// See EventLoop.run
     public func run() {
-        /// FIXME: this run is a `-> Never` which will
-        /// only work correctly if `run()` or `runLoop()` is called only once.
-        RunLoop.main.run()
+        // From the documentation of RunLoop.run():
+        // "If no input sources or timers are attached to the run loop, this method exits immediately."
+
+        // To avoid this, the following block creates a pending timer far into the future to keep the run loop
+        // alive until sockets are connected.
+        if #available(OSX 10.12, *) {
+            // New syntax for macOS 10.12+ and Linux
+            _ = Timer.scheduledTimer(withTimeInterval: TimeInterval.greatestFiniteMagnitude,
+                                     repeats: true,
+                                     block: { _ in })
+        } else {
+            // Fallback on earlier macOS versions
+            #if os(macOS)
+            _ = Timer.scheduledTimer(timeInterval: TimeInterval.greatestFiniteMagnitude,
+                                     target: self,
+                                     selector: #selector(keepAlive),
+                                     userInfo: nil,
+                                     repeats: true)
+            #endif
+        }
+
+        RunLoop.current.run()
+    }
+
+    @objc private func keepAlive() {
     }
 }


### PR DESCRIPTION
Disclaimer: This might not be relevant if Dispatch is replaced with epoll on Linux, and might cause trouble with the unit tests on that branch. I still wanted to throw this in for show.

While investigating the high load after the process is started, I found that `run()` did not block at all, causing the outer infinite loop to spin. As noted in my comment, `RunLoop.run()` immediately exits if there are no sources or timers attached to it – leaving us in a chicken-or-egg situation, as sockets will be registered later on to the event loop.

To work around this, I added a long pending timer to keep the loop alive. This fixed the spinning and the high CPU load. (Unfortunately, the beta is still returning empty responses on Linux.)