### PR TITLE
omit  where expectation is the same

### DIFF
--- a/Sources/Async/Futures/Future+Map.swift
+++ b/Sources/Async/Futures/Future+Map.swift
@@ -50,6 +50,20 @@ public func ??<T>(lhs: Future<T?>, rhs: T) -> Future<T> {
     }
 }
 
+/// MARK: Same type
+
+extension Future {
+    /// See `Future.map`
+    public func map(_ callback: @escaping (Expectation) throws -> Expectation) -> Future<Expectation> {
+        return map(to: Expectation.self, callback)
+    }
+
+    /// See `Future.flatMap`
+    public func flatMap(_ callback: @escaping (Expectation) throws -> Future<Expectation>) -> Future<Expectation> {
+        return flatMap(to: Expectation.self, callback)
+    }
+}
+
 /// MARK: Array
 
 extension Array where Element: FutureType {


### PR DESCRIPTION
This allows for omitting the `to:` label (in an ambiguous-safe way) by limiting it to returns of the same expectation. This helps to cut down on unnecessary noise. 

```swift
return asyncThing1().flatMap(to: Void.self) {
    return asyncThing1()
}.flatMap(to: Void.self) {
    return asyncThing1()
}.flatMap(to: Bool.self) {
    return asyncThing2()
}.flatMap(to: Bool.self) {
    return asyncThing2()
}
```

Becomes:


```swift
return asyncThing1().flatMap {
    return asyncThing1()
}.flatMap {
    return asyncThing1()
}.flatMap(to: Bool.self) {
    return asyncThing2()
}.flatMap {
    return asyncThing2()
}
```