### PR TITLE
Add convenience function for returning void in a future

### DIFF
--- a/Sources/Async/Futures/Void.swift
+++ b/Sources/Async/Futures/Void.swift
@@ -1,0 +1,9 @@
+extension Future where T == Void {
+
+    /// Convenience function for returning void inside a future
+    public static var void: Void {
+        return _void
+    }
+}
+
+private let _void: Void = {}()


### PR DESCRIPTION
As discussed in Slack with the community, this allows you to return `void` inside a future that requires something to return. E.g.

```swift
static func addTag(_ name: String, to post: BlogPost<Database>, on conn: DatabaseConnectable) throws -> Future<Void> {
    return BlogTag.query(on: conn).filter(\.name == name).first().flatMap(to: Void.self) { foundTag in
        var pivotTag: BlogTag
        if let exisitingTag = foundTag {
            pivotTag = exisitingTag
        } else {
            pivotTag = BlogTag(name: name)
        }
        return pivotTag.posts.attach(post, on: conn).map(to: Void.self) { _ in

        }
    }
}
```

can become:

```swift
static func addTag(_ name: String, to post: BlogPost<Database>, on conn: DatabaseConnectable) throws -> Future<Void> {
    return BlogTag.query(on: conn).filter(\.name == name).first().flatMap(to: Void.self) { foundTag in
        var pivotTag: BlogTag
        if let exisitingTag = foundTag {
            pivotTag = exisitingTag
        } else {
            pivotTag = BlogTag(name: name)
        }
        return pivotTag.posts.attach(post, on: conn).transform(to: Future.void)
    }
}
```

Which reduces a level of (empty) nesting, and tidies it up a bit. Thoughts?