### PR TITLE
Adds `assertEquals()` and `guard()` functions

### DIFF
--- a/Sources/Async/Futures/Future.swift
+++ b/Sources/Async/Futures/Future.swift
@@ -128,7 +128,7 @@ public extension Future where T == Bool {
     /// Acts guards against whatever it's being chained with
     /// If true, continue the chain
     /// Else, throw the supplied error
-    public func `guard`(elseThrow error: Error) throws -> Future<Bool> {
+    public func `guard`(elseThrow error: Error) -> Future<Bool> {
         return self.map(to: Bool.self) { (check) in
             guard check else {throw error}
             return check

--- a/Sources/Async/Futures/Future.swift
+++ b/Sources/Async/Futures/Future.swift
@@ -121,6 +121,14 @@ public extension Future where T: Equatable {
             return currentVal == val
         }
     }
+    
+    /// Assert the value being passed along the chain is equal to one of many values
+    /// Return true if it is, false if it's not
+    public func assertEquals(_ vals: T...) -> Future<Bool> {
+        return self.map(to: Bool.self) { (currentVal) in
+            return vals.contains(currentVal)
+        }
+    }
 }
 
 public extension Future where T == Bool {

--- a/Sources/Async/Futures/Future.swift
+++ b/Sources/Async/Futures/Future.swift
@@ -113,5 +113,28 @@ public struct Future<T>: FutureType {
     }
 }
 
+public extension Future where T: Equatable {
+    /// Assert the value being passed along the chain is equal to the value passed in
+    /// Return true if it is, false if it's not
+    public func assertEquals(_ val: T) -> Future<Bool> {
+        return self.map(to: Bool.self) { (currentVal) in
+            return currentVal == val
+        }
+    }
+}
+
+public extension Future where T == Bool {
+    
+    /// Acts guards against whatever it's being chained with
+    /// If true, continue the chain
+    /// Else, throw the supplied error
+    public func `guard`(elseThrow error: Error) throws -> Future<Bool> {
+        return self.map(to: Bool.self) { (check) in
+            guard check else {throw error}
+            return check
+        }
+    }
+}
+
 /// Thrown when a future is asserted as completed but wasn't completed
 fileprivate struct UncompletedFuture: Error {}

--- a/Sources/Async/Futures/Future.swift
+++ b/Sources/Async/Futures/Future.swift
@@ -136,6 +136,7 @@ public extension Future where T == Bool {
     /// Acts guards against whatever it's being chained with
     /// If true, continue the chain
     /// Else, throw the supplied error
+    @discardableResult
     public func `guard`(elseThrow error: Error) -> Future<Bool> {
         return self.map(to: Bool.self) { (check) in
             guard check else {throw error}


### PR DESCRIPTION
Let me know if you want them moved into their own extension files. Example usage:

```swift
User.query(on: req)
    .filter(\.email == registerRequest.email)
    .count()
    .assertEquals(0)
    .guard(elseThrow: userExistsError)
    .saveUserWith(
        name: registerRequest.name,
        email: registerRequest.email,
        password: registerRequest.password,
        on: req
    )
```