### PR TITLE
flattens any future into void

### DIFF
--- a/Sources/Async/Futures/FutureType.swift
+++ b/Sources/Async/Futures/FutureType.swift
@@ -180,6 +180,15 @@ public func then<T>(_ callback: @escaping () throws -> Future<T>) -> Future<T> {
 
 // MARK: Void
 
+extension Future {
+    /// Flattens any future into void
+    public func flatten() -> Future<Void> {
+        return map(to: Void.self, { (_) -> Void in
+            return Void()
+        })
+    }
+}
+
 extension Future where T == Void {
     /// Pre-completed void future.
     public static var done: Future<Void> {


### PR DESCRIPTION
using this in my app to transform any future to void easily and was wondering if you think it could be useful elsewhere ... obviously would add tests if so

Also, in my app I have the extension constrained to `Content` so it doesn't show on `Future<Void>` which would be pointless but not sure how to do this in pure async ...