### PR TITLE
Feature/future extensions

### DIFF
--- a/Sources/Async/Futures/Future+Bool.swift
+++ b/Sources/Async/Futures/Future+Bool.swift
@@ -1,0 +1,19 @@
+public extension Future where T == Bool {
+    public func `true`(or error: Error) throws -> Future<Bool> {
+        return self.map(to: Bool.self) { boolean in
+            if !boolean {
+                throw error
+            }
+            return boolean
+        }
+    }
+
+    public func `false`(or error: Error) throws -> Future<Bool> {
+        return self.map(to: Bool.self) { boolean in
+            if boolean {
+                throw error
+            }
+            return !boolean
+        }
+    }
+}

--- a/Sources/Async/Futures/Future+Equatable.swift
+++ b/Sources/Async/Futures/Future+Equatable.swift
@@ -1,0 +1,25 @@
+public extension Future where T: Equatable {
+    public func equal(to value: T) -> Future<Bool> {
+        return self.map(to: Bool.self) { current in
+            return current == value
+        }
+    }
+    
+    public func equal(to value: T, or error: Error) throws -> Future<Bool> {
+        return try self.map(to: Bool.self) { current in
+            return current == value
+        }.true(or: error)
+    }
+
+    public func notEqual(to value: T) -> Future<Bool> {
+        return self.map(to: Bool.self) { current in
+            return current != value
+        }
+    }
+    
+    public func notEqual(to value: T, or error: Error) throws -> Future<Bool> {
+        return try self.map(to: Bool.self) { current in
+            return current != value
+        }.true(or: error)
+    }
+}

--- a/Tests/AsyncTests/FutureTests.swift
+++ b/Tests/AsyncTests/FutureTests.swift
@@ -309,6 +309,56 @@ final class FutureTests : XCTestCase {
         XCTAssertEqual(try future0.blockingAwait(), "Hello, World!")
         XCTAssertEqual(try future1.blockingAwait(), "Hello, World! :)")
     }
+    
+    func testFutureTrue() throws {
+        let t = Future(true)
+        let f = Future(false)
+        
+        XCTAssertEqual(try t.true(or: CustomError()).blockingAwait(), true)
+        XCTAssertThrowsError(try f.true(or: CustomError()).blockingAwait())
+    }
+    
+    func testFutureFalse() throws {
+        let t = Future(true)
+        let f = Future(false)
+        
+        XCTAssertThrowsError(try t.false(or: CustomError()).blockingAwait())
+        XCTAssertEqual(try f.false(or: CustomError()).blockingAwait(), true)
+    }
+    
+    func testFutureEqual() throws {
+        let f1 = Future(34)
+        let f2 = Future("string")
+        
+        XCTAssertEqual(try f1.equal(to: 34).blockingAwait(), true)
+        XCTAssertEqual(try f1.equal(to: 30).blockingAwait(), false)
+        
+        XCTAssertNoThrow(try f1.equal(to: 34, or: CustomError()).blockingAwait())
+        XCTAssertThrowsError(try f1.equal(to: 30, or: CustomError()).blockingAwait())
+        
+        XCTAssertEqual(try f2.equal(to: "string").blockingAwait(), true)
+        XCTAssertEqual(try f2.equal(to: "not-equal").blockingAwait(), false)
+        
+        XCTAssertNoThrow(try f2.equal(to: "string", or: CustomError()).blockingAwait())
+        XCTAssertThrowsError(try f2.equal(to: "not-equal", or: CustomError()).blockingAwait())
+    }
+    
+    func testFutureNotEqual() throws {
+        let f1 = Future(34)
+        let f2 = Future("string")
+    
+        XCTAssertEqual(try f1.notEqual(to: 34).blockingAwait(), false)
+        XCTAssertEqual(try f1.notEqual(to: 30).blockingAwait(), true)
+        
+        XCTAssertThrowsError(try f1.notEqual(to: 34, or: CustomError()).blockingAwait())
+        XCTAssertNoThrow(try f1.notEqual(to: 30, or: CustomError()).blockingAwait())
+        
+        XCTAssertEqual(try f2.notEqual(to: "string").blockingAwait(), false)
+        XCTAssertEqual(try f2.notEqual(to: "not-equal").blockingAwait(), true)
+        
+        XCTAssertThrowsError(try f2.notEqual(to: "string", or: CustomError()).blockingAwait())
+        XCTAssertNoThrow(try f2.notEqual(to: "not-equal", or: CustomError()).blockingAwait())
+    }
 
     static let allTests = [
         ("testSimpleFuture", testSimpleFuture),
@@ -329,6 +379,10 @@ final class FutureTests : XCTestCase {
         ("testCoalescing", testCoalescing),
         ("testFutureFlatMapErrors2", testFutureFlatMapErrors2),
         ("testPrecompleted", testPrecompleted),
+        ("testFutureTrue", testFutureTrue),
+        ("testFutureFalse", testFutureFalse),
+        ("testFutureEqual", testFutureEqual),
+        ("testFutureNotEqual", testFutureNotEqual),
     ]
 }
 


### PR DESCRIPTION
# Usage Examples:

### True / Equal
```
    func register(_ req: Request, body: User.RegisterRequest) throws -> Future<User> {
        return try User.query(on: req)
            .filter(\User.email == body.email.lowercased())
            .count()
            // ---> Begin Example
            .equal(to: 0)
            .true(or: Abort(.badRequest, reason: "User exists!"))
            // ---> Or combine
            .equal(to: 0, or: Abort(.badRequest, reason: "User exists!"))
            // ---> End example
            .flatMap(to: User.self) { incoming in
                let hasher = try req.make(BCryptHasher.self)
                let hashedPassword = try hasher.make(body.password)
                let user = User(name: body.name, email: body.email, password: hashedPassword)
                return user.save(on: req)
        }
    }
```