### PR TITLE
add and that takes one and two future

### DIFF
--- a/Sources/Async/Futures/Future+And.swift
+++ b/Sources/Async/Futures/Future+And.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+extension Future {
+    /// Merges the result of two futures into a tuple.
+    public func and<S>(_ otherFuture: Future<S>) -> Future<(T, S)> {
+        return self.flatMap(to: (T, S).self, { (thisExpectation: T) -> Future<(T, S)> in
+            return otherFuture.map(to: (T, S).self, { (otherExpectation: S) in
+                return (thisExpectation, otherExpectation)
+            })
+        })
+    }
+
+    /// Merges the result of three futures into a tuple.
+    public func and<S, V>(_ otherFuture: Future<S>, _ yetAnotherFuture: Future<V>) -> Future<(T, S, V)> {
+        return self.and(otherFuture).flatMap(to: (T, S, V).self, { (tAndS) in
+            let t = tAndS.0
+            let s = tAndS.1
+            return yetAnotherFuture.map(to: (T, S, V).self, { (v) in
+                (t, s, v)
+            })
+        })
+    }
+}

--- a/Tests/AsyncTests/FutureTests.swift
+++ b/Tests/AsyncTests/FutureTests.swift
@@ -310,6 +310,23 @@ final class FutureTests : XCTestCase {
         XCTAssertEqual(try future1.blockingAwait(), "Hello, World! :)")
     }
 
+    func testAnd() throws {
+        let hello = Future("Hello")
+        let world = Future("World")
+        let smiley = Future(":)")
+
+        let helloWorldFuture = hello.and(world).map(to: String.self) { (helloAndWorld) in
+            "\(helloAndWorld.0) \(helloAndWorld.1)!"
+        }
+
+        let helloWorldSmileyFuture = hello.and(world, smiley).map(to: String.self) { (helloAndWorldAndSmiley) in
+            "\(helloAndWorldAndSmiley.0) \(helloAndWorldAndSmiley.1) \(helloAndWorldAndSmiley.2)!"
+        }
+
+        XCTAssertEqual(try helloWorldFuture.blockingAwait(), "Hello World!")
+        XCTAssertEqual(try helloWorldSmileyFuture.blockingAwait(), "Hello World :)!")
+    }
+
     static let allTests = [
         ("testSimpleFuture", testSimpleFuture),
         ("testFutureThen", testFutureThen),
@@ -329,6 +346,7 @@ final class FutureTests : XCTestCase {
         ("testCoalescing", testCoalescing),
         ("testFutureFlatMapErrors2", testFutureFlatMapErrors2),
         ("testPrecompleted", testPrecompleted),
+        ("testAnd", testAnd)
     ]
 }
 


### PR DESCRIPTION
This PR is to add the "and" syntactic sugar to the future structure. 

## Motivations:
Often times when working with vapor we have to get futures from multiple places such as body content, and database connections. Joining these together to work with them in Map chaining is nice syntactic sugar.


## Limitations:
It seems that tuples can be destructured into arguments according to the compiler, the systactic sugar is nice, but not as nice as I would like.

#### Acctual
```swift
var futureT = Future(t)
var futureS = Future(s)

futureT.and(futureS).map(to: V.self) { tAndS in

 return ///
} 

```

#### Desired

```swift
var futureT = Future(t)
var futureS = Future(s)

futureT.and(futureS).map(to: V.self) { t, s in

 return ///
} 

```

## Future Thoughts:

It would be nice if generics could handle Type lists, however, I think this beyond the scope of what swift 4 can do at the moment as such making a generic that can handle variadic arguments is beyond the scope of this work. I could definitely be wrong and there could be  a way to hand N amount of futures in which case, lets do it.
