### PR TITLE
stream error + source/sink cleanup

### DIFF
--- a/Sources/Async/EventLoop/Epoll/EpollEventLoop.swift
+++ b/Sources/Async/EventLoop/Epoll/EpollEventLoop.swift
@@ -80,7 +80,8 @@ public final class EpollEventLoop: EventLoop {
         let t = timeout.flatMap { Int32($0.milliseconds) } ?? -1
         let eventCount = epoll_wait(epfd, eventlist.baseAddress, Int32(eventlist.count), t)
         guard eventCount >= 0 else {
-            fatalError("An error occured while running kevent: \(eventCount).")
+            ERROR("An error occured while running kevent: \(eventCount).")
+            return
         }
 
         /// print("[\(label)] \(eventCount) New Events")

--- a/Sources/Async/EventLoop/Epoll/EpollEventSource.swift
+++ b/Sources/Async/EventLoop/Epoll/EpollEventSource.swift
@@ -49,7 +49,7 @@ public final class EpollEventSource: EventSource {
         case .timer(let timeout):
             let tfd = timerfd_create(CLOCK_MONOTONIC, Int32(TFD_NONBLOCK))
             if tfd == -1 {
-                fatalError("timerfd_create() failed: errno=\(errno)")
+                ERROR("timerfd_create() failed: errno=\(errno)")
             }
 
             var ts = itimerspec()
@@ -90,9 +90,9 @@ public final class EpollEventSource: EventSource {
     public func suspend() {
         switch state {
         case .cancelled:
-            fatalError("Called `.suspend()` on a cancelled EpollEventSource.")
+            ERROR("Called `.suspend()` on a cancelled EpollEventSource.")
         case .suspended:
-            fatalError("Called `.suspend()` on a suspended EpollEventSource.")
+            ERROR("Called `.suspend()` on a suspended EpollEventSource.")
         case .resumed:
             state = .suspended
             update(op: EPOLL_CTL_DEL)
@@ -103,12 +103,12 @@ public final class EpollEventSource: EventSource {
     public func resume() {
         switch state {
         case .cancelled:
-            fatalError("Called `.resume()` on a cancelled EpollEventSource.")
+            ERROR("Called `.resume()` on a cancelled EpollEventSource.")
         case .suspended:
             state = .resumed
             update(op: EPOLL_CTL_ADD)
         case .resumed:
-            fatalError("Called `.resume()` on a resumed EpollEventSource.")
+            ERROR("Called `.resume()` on a resumed EpollEventSource.")
         }
     }
 
@@ -120,8 +120,8 @@ public final class EpollEventSource: EventSource {
         }
 
         switch state {
-        case .cancelled: fatalError("Called `.cancel()` on a cancelled EpollEventSource.")
-        case .resumed: fatalError("Called `.cancel()` on a resumed EpollEventSource.")
+        case .cancelled: ERROR("Called `.cancel()` on a cancelled EpollEventSource.")
+        case .resumed: ERROR("Called `.cancel()` on a resumed EpollEventSource.")
         case .suspended:
             switch type {
             case .timer: close(event.data.fd)

--- a/Sources/Async/EventLoop/EventLoop.swift
+++ b/Sources/Async/EventLoop/EventLoop.swift
@@ -87,7 +87,7 @@ extension Thread {
                 work()
             }
         } else {
-            fatalError()
+            ERROR("Thead.async requires macOS 10.12 or greater")
         }
     }
 }

--- a/Sources/Async/EventLoop/Kqueue/KqueueEventSource.swift
+++ b/Sources/Async/EventLoop/Kqueue/KqueueEventSource.swift
@@ -67,9 +67,9 @@ public final class KqueueEventSource: EventSource {
         DEBUG("KqueueEventSource.suspend() [\(event)]")
         switch state {
         case .cancelled:
-            fatalError("Called `.suspend()` on a cancelled KqueueEventSource.")
+            ERROR("Called `.suspend()` on a cancelled KqueueEventSource.")
         case .suspended:
-            fatalError("Called `.suspend()` on a suspended KqueueEventSource.")
+            ERROR("Called `.suspend()` on a suspended KqueueEventSource.")
         case .resumed:
             event.flags = EV_ADD | EV_DISABLE
             state = .suspended
@@ -82,7 +82,7 @@ public final class KqueueEventSource: EventSource {
         DEBUG("KqueueEventSource.resume() [\(event)]")
         switch state {
         case .cancelled:
-            fatalError("Called `.resume()` on a cancelled KqueueEventSource.")
+            ERROR("Called `.resume()` on a cancelled KqueueEventSource.")
         case .suspended:
             if event.flags & EV_ONESHOT > 0 {
                 event.flags = EV_ADD | EV_ENABLE | EV_ONESHOT
@@ -94,7 +94,7 @@ public final class KqueueEventSource: EventSource {
                 update()
             }
         case .resumed:
-            fatalError("Called `.resume()` on a resumed KqueueEventSource.")
+            ERROR("Called `.resume()` on a resumed KqueueEventSource.")
         }
     }
 
@@ -102,7 +102,7 @@ public final class KqueueEventSource: EventSource {
     public func cancel() {
         DEBUG("KqueueEventSource.cancel() [\(event)]")
         switch state {
-        case .cancelled: fatalError("Called `.cancel()` on a cancelled KqueueEventSource.")
+        case .cancelled: ERROR("Called `.cancel()` on a cancelled KqueueEventSource.")
         case .resumed, .suspended:
             event.flags = EV_DELETE
             state = .cancelled
@@ -136,7 +136,7 @@ public final class KqueueEventSource: EventSource {
             let reason = String(cString: strerror(errno))
             switch errno {
             case ENOENT: break // event has already been deleted
-            default: fatalError("An error occured during KqueueEventSource.update: \(reason)")
+            default: ERROR("An error occured during KqueueEventSource.update: \(reason)")
             }
         }
     }

--- a/Sources/Async/Socket/SocketSource.swift
+++ b/Sources/Async/Socket/SocketSource.swift
@@ -4,6 +4,7 @@ import Foundation
 private let maxExcessSignalCount: Int = 2
 
 /// Data stream wrapper for a dispatch socket.
+@available(*, deprecated)
 public final class SocketSource<Socket>: OutputStream
     where Socket: Async.Socket
 {
@@ -69,7 +70,8 @@ public final class SocketSource<Socket>: OutputStream
             return
         }
         guard let readSource = self.readSource else {
-            fatalError("SocketSource readSource illegally nil during close.")
+            ERROR("SocketSource readSource illegally nil during close.")
+            return
         }
         readSource.cancel()
         socket.close()
@@ -84,7 +86,8 @@ public final class SocketSource<Socket>: OutputStream
     /// as indicated by a read source.
     private func readData() {
         guard let downstream = self.downstream else {
-            fatalError("Unexpected nil downstream on SocketSource during readData.")
+            ERROR("Unexpected nil downstream on SocketSource during readData.")
+            return
         }
         do {
             let read = try socket.read(into: buffer)
@@ -141,7 +144,8 @@ public final class SocketSource<Socket>: OutputStream
             excessSignalCount = excessSignalCount &+ 1
             if excessSignalCount >= maxExcessSignalCount {
                 guard let readSource = self.readSource else {
-                    fatalError("SocketSource readSource illegally nil during signal.")
+                    ERROR("SocketSource readSource illegally nil during signal.")
+                    return
                 }
                 readSource.suspend()
                 sourceIsSuspended = true
@@ -161,7 +165,8 @@ public final class SocketSource<Socket>: OutputStream
         }
 
         guard let readSource = self.readSource else {
-            fatalError("SocketSource readSource illegally nil on resumeIfSuspended.")
+            ERROR("SocketSource readSource illegally nil on resumeIfSuspended.")
+            return
         }
         sourceIsSuspended = false
         readSource.resume()
@@ -177,6 +182,7 @@ public final class SocketSource<Socket>: OutputStream
 
 extension Socket {
     /// Creates a data stream for this socket on the supplied event loop.
+    @available(*, deprecated)
     public func source(on eventLoop: Worker, bufferSize: Int = 4096) -> SocketSource<Self> {
         return .init(socket: self, on: eventLoop, bufferSize: bufferSize)
     }

--- a/Sources/Async/Socket/SocketStream.swift
+++ b/Sources/Async/Socket/SocketStream.swift
@@ -8,6 +8,7 @@ extension ByteStream {
 }
 
 /// A socket-based byte stream.
+@available(*, deprecated)
 public final class SocketStream<Socket>: ByteStream where Socket: Async.Socket {
     /// Socket source output stream.
     private let source: SocketSource<Socket>
@@ -34,6 +35,7 @@ public final class SocketStream<Socket>: ByteStream where Socket: Async.Socket {
 
 extension Socket {
     /// Creates a `SocketStream` for this socket.
+    @available(*, deprecated)
     public func stream(on worker: Worker, onError: @escaping SocketSink<Self>.ErrorHandler) -> SocketStream<Self> {
         return .init(socket: self, on: worker, onError: onError)
     }
@@ -42,7 +44,7 @@ extension Socket {
     @available(*, deprecated)
     public func stream(on worker: Worker) -> SocketStream<Self> {
         return .init(socket: self, on: worker) { _, error in
-            fatalError("Uncaught error in SocketStream: \(error).")
+            ERROR("Uncaught error in SocketStream: \(error).")
         }
     }
 }


### PR DESCRIPTION
- [x] removes all `fatalError`
- [x] deprecates SocketSink/Source (in favor of TCP/TLS specific ones in respective repos)
- [x] addresses #75