### PR TITLE
Generalize the working directory configuration.

### DIFF
--- a/Sources/Async/File/DirectoryConfig.swift
+++ b/Sources/Async/File/DirectoryConfig.swift
@@ -16,40 +16,23 @@ public struct DirectoryConfig {
 
     /// Creates a directory config with default working directory.
     public static func detect() -> DirectoryConfig {
-        let fileBasedWorkDir: String?
+        var workDir: String
 
-        #if Xcode
-            // attempt to find working directory through #file
-            let file = #file
-
-            if file.contains(".build") {
-                // most dependencies are in `./.build/`
-                fileBasedWorkDir = file.components(separatedBy: "/.build").first
-            } else if file.contains("Packages") {
-                // when editing a dependency, it is in `./Packages/`
-                fileBasedWorkDir = file.components(separatedBy: "/Packages").first
-            } else {
-                // when dealing with current repository, file is in `./Sources/`
-                fileBasedWorkDir = file.components(separatedBy: "/Sources").first
-            }
-        #else
-            fileBasedWorkDir = nil
-        #endif
-
-        let workDir: String
-        if let fileBasedWorkDir = fileBasedWorkDir {
-            workDir = fileBasedWorkDir
+        let cwd = getcwd(nil, Int(PATH_MAX))
+        defer {
+            free(cwd)
+        }
+        if let cwd = cwd, let string = String(validatingUTF8: cwd) {
+            workDir = string
         } else {
-            // get actual working directory
-            let cwd = getcwd(nil, Int(PATH_MAX))
-            defer {
-                free(cwd)
-            }
+            workDir = "./"
+        }
 
-            if let cwd = cwd, let string = String(validatingUTF8: cwd) {
-                workDir = string
-            } else {
-                workDir = "./"
+        let standardPaths = [".build", "Packages", "Sources"]
+        for path in standardPaths {
+            if workDir.contains(path){
+                workDir = workDir.components(separatedBy:"/\(path)").first!
+                break
             }
         }
 


### PR DESCRIPTION
- One can launch the application from the ```.build``` or other folders even from the command-line, not necessarily from the Xcode
- ```#if Xcode``` requires each IDE to use the same preprocessor definition as Xcode does and that's not good since we need to introduce another entity for the particular run configuration in the particular IDE. 
